### PR TITLE
kkcd-48: use github secrets for registry login

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -15,5 +15,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io/kamukirim
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build & Push All
         run: ./build.bash push


### PR DESCRIPTION
this should fix the `after-merge` workflow, please review